### PR TITLE
Updated command line tool to operate with OpenCV4

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,8 +1,8 @@
 Installation Instructions
 *************************
 
-Copyright (C) 1994-1996, 1999-2002, 2004-2013 Free Software Foundation,
-Inc.
+   Copyright (C) 1994-1996, 1999-2002, 2004-2017, 2020-2021 Free
+Software Foundation, Inc.
 
    Copying and distribution of this file, with or without modification,
 are permitted in any medium without royalty provided the copyright
@@ -12,97 +12,96 @@ without warranty of any kind.
 Basic Installation
 ==================
 
-   Briefly, the shell command `./configure && make && make install'
+   Briefly, the shell command './configure && make && make install'
 should configure, build, and install this package.  The following
-more-detailed instructions are generic; see the `README' file for
+more-detailed instructions are generic; see the 'README' file for
 instructions specific to this package.  Some packages provide this
-`INSTALL' file but do not implement all of the features documented
+'INSTALL' file but do not implement all of the features documented
 below.  The lack of an optional feature in a given package is not
 necessarily a bug.  More recommendations for GNU packages can be found
 in *note Makefile Conventions: (standards)Makefile Conventions.
 
-   The `configure' shell script attempts to guess correct values for
+   The 'configure' shell script attempts to guess correct values for
 various system-dependent variables used during compilation.  It uses
-those values to create a `Makefile' in each directory of the package.
-It may also create one or more `.h' files containing system-dependent
-definitions.  Finally, it creates a shell script `config.status' that
+those values to create a 'Makefile' in each directory of the package.
+It may also create one or more '.h' files containing system-dependent
+definitions.  Finally, it creates a shell script 'config.status' that
 you can run in the future to recreate the current configuration, and a
-file `config.log' containing compiler output (useful mainly for
-debugging `configure').
+file 'config.log' containing compiler output (useful mainly for
+debugging 'configure').
 
-   It can also use an optional file (typically called `config.cache'
-and enabled with `--cache-file=config.cache' or simply `-C') that saves
-the results of its tests to speed up reconfiguring.  Caching is
-disabled by default to prevent problems with accidental use of stale
-cache files.
+   It can also use an optional file (typically called 'config.cache' and
+enabled with '--cache-file=config.cache' or simply '-C') that saves the
+results of its tests to speed up reconfiguring.  Caching is disabled by
+default to prevent problems with accidental use of stale cache files.
 
    If you need to do unusual things to compile the package, please try
-to figure out how `configure' could check whether to do them, and mail
-diffs or instructions to the address given in the `README' so they can
+to figure out how 'configure' could check whether to do them, and mail
+diffs or instructions to the address given in the 'README' so they can
 be considered for the next release.  If you are using the cache, and at
-some point `config.cache' contains results you don't want to keep, you
+some point 'config.cache' contains results you don't want to keep, you
 may remove or edit it.
 
-   The file `configure.ac' (or `configure.in') is used to create
-`configure' by a program called `autoconf'.  You need `configure.ac' if
-you want to change it or regenerate `configure' using a newer version
-of `autoconf'.
+   The file 'configure.ac' (or 'configure.in') is used to create
+'configure' by a program called 'autoconf'.  You need 'configure.ac' if
+you want to change it or regenerate 'configure' using a newer version of
+'autoconf'.
 
    The simplest way to compile this package is:
 
-  1. `cd' to the directory containing the package's source code and type
-     `./configure' to configure the package for your system.
+  1. 'cd' to the directory containing the package's source code and type
+     './configure' to configure the package for your system.
 
-     Running `configure' might take a while.  While running, it prints
+     Running 'configure' might take a while.  While running, it prints
      some messages telling which features it is checking for.
 
-  2. Type `make' to compile the package.
+  2. Type 'make' to compile the package.
 
-  3. Optionally, type `make check' to run any self-tests that come with
+  3. Optionally, type 'make check' to run any self-tests that come with
      the package, generally using the just-built uninstalled binaries.
 
-  4. Type `make install' to install the programs and any data files and
+  4. Type 'make install' to install the programs and any data files and
      documentation.  When installing into a prefix owned by root, it is
      recommended that the package be configured and built as a regular
-     user, and only the `make install' phase executed with root
+     user, and only the 'make install' phase executed with root
      privileges.
 
-  5. Optionally, type `make installcheck' to repeat any self-tests, but
+  5. Optionally, type 'make installcheck' to repeat any self-tests, but
      this time using the binaries in their final installed location.
      This target does not install anything.  Running this target as a
-     regular user, particularly if the prior `make install' required
+     regular user, particularly if the prior 'make install' required
      root privileges, verifies that the installation completed
      correctly.
 
   6. You can remove the program binaries and object files from the
-     source code directory by typing `make clean'.  To also remove the
-     files that `configure' created (so you can compile the package for
-     a different kind of computer), type `make distclean'.  There is
-     also a `make maintainer-clean' target, but that is intended mainly
+     source code directory by typing 'make clean'.  To also remove the
+     files that 'configure' created (so you can compile the package for
+     a different kind of computer), type 'make distclean'.  There is
+     also a 'make maintainer-clean' target, but that is intended mainly
      for the package's developers.  If you use it, you may have to get
      all sorts of other programs in order to regenerate files that came
      with the distribution.
 
-  7. Often, you can also type `make uninstall' to remove the installed
+  7. Often, you can also type 'make uninstall' to remove the installed
      files again.  In practice, not all packages have tested that
      uninstallation works correctly, even though it is required by the
      GNU Coding Standards.
 
-  8. Some packages, particularly those that use Automake, provide `make
+  8. Some packages, particularly those that use Automake, provide 'make
      distcheck', which can by used by developers to test that all other
-     targets like `make install' and `make uninstall' work correctly.
+     targets like 'make install' and 'make uninstall' work correctly.
      This target is generally not run by end users.
 
 Compilers and Options
 =====================
 
    Some systems require unusual options for compilation or linking that
-the `configure' script does not know about.  Run `./configure --help'
+the 'configure' script does not know about.  Run './configure --help'
 for details on some of the pertinent environment variables.
 
-   You can give `configure' initial values for configuration parameters
-by setting variables in the command line or in the environment.  Here
-is an example:
+   You can give 'configure' initial values for configuration parameters
+by setting variables in the command line or in the environment.  Here is
+an example:
 
      ./configure CC=c99 CFLAGS=-g LIBS=-lposix
 
@@ -113,21 +112,21 @@ Compiling For Multiple Architectures
 
    You can compile the package for more than one kind of computer at the
 same time, by placing the object files for each architecture in their
-own directory.  To do this, you can use GNU `make'.  `cd' to the
+own directory.  To do this, you can use GNU 'make'.  'cd' to the
 directory where you want the object files and executables to go and run
-the `configure' script.  `configure' automatically checks for the
-source code in the directory that `configure' is in and in `..'.  This
-is known as a "VPATH" build.
+the 'configure' script.  'configure' automatically checks for the source
+code in the directory that 'configure' is in and in '..'.  This is known
+as a "VPATH" build.
 
-   With a non-GNU `make', it is safer to compile the package for one
+   With a non-GNU 'make', it is safer to compile the package for one
 architecture at a time in the source code directory.  After you have
-installed the package for one architecture, use `make distclean' before
+installed the package for one architecture, use 'make distclean' before
 reconfiguring for another architecture.
 
    On MacOS X 10.5 and later systems, you can create libraries and
 executables that work on multiple system types--known as "fat" or
-"universal" binaries--by specifying multiple `-arch' options to the
-compiler but only a single `-arch' option to the preprocessor.  Like
+"universal" binaries--by specifying multiple '-arch' options to the
+compiler but only a single '-arch' option to the preprocessor.  Like
 this:
 
      ./configure CC="gcc -arch i386 -arch x86_64 -arch ppc -arch ppc64" \
@@ -136,105 +135,104 @@ this:
 
    This is not guaranteed to produce working output in all cases, you
 may have to build one architecture at a time and combine the results
-using the `lipo' tool if you have problems.
+using the 'lipo' tool if you have problems.
 
 Installation Names
 ==================
 
-   By default, `make install' installs the package's commands under
-`/usr/local/bin', include files under `/usr/local/include', etc.  You
-can specify an installation prefix other than `/usr/local' by giving
-`configure' the option `--prefix=PREFIX', where PREFIX must be an
+   By default, 'make install' installs the package's commands under
+'/usr/local/bin', include files under '/usr/local/include', etc.  You
+can specify an installation prefix other than '/usr/local' by giving
+'configure' the option '--prefix=PREFIX', where PREFIX must be an
 absolute file name.
 
    You can specify separate installation prefixes for
 architecture-specific files and architecture-independent files.  If you
-pass the option `--exec-prefix=PREFIX' to `configure', the package uses
+pass the option '--exec-prefix=PREFIX' to 'configure', the package uses
 PREFIX as the prefix for installing programs and libraries.
 Documentation and other data files still use the regular prefix.
 
    In addition, if you use an unusual directory layout you can give
-options like `--bindir=DIR' to specify different values for particular
-kinds of files.  Run `configure --help' for a list of the directories
-you can set and what kinds of files go in them.  In general, the
-default for these options is expressed in terms of `${prefix}', so that
-specifying just `--prefix' will affect all of the other directory
+options like '--bindir=DIR' to specify different values for particular
+kinds of files.  Run 'configure --help' for a list of the directories
+you can set and what kinds of files go in them.  In general, the default
+for these options is expressed in terms of '${prefix}', so that
+specifying just '--prefix' will affect all of the other directory
 specifications that were not explicitly provided.
 
    The most portable way to affect installation locations is to pass the
-correct locations to `configure'; however, many packages provide one or
+correct locations to 'configure'; however, many packages provide one or
 both of the following shortcuts of passing variable assignments to the
-`make install' command line to change installation locations without
+'make install' command line to change installation locations without
 having to reconfigure or recompile.
 
    The first method involves providing an override variable for each
-affected directory.  For example, `make install
+affected directory.  For example, 'make install
 prefix=/alternate/directory' will choose an alternate location for all
 directory configuration variables that were expressed in terms of
-`${prefix}'.  Any directories that were specified during `configure',
-but not in terms of `${prefix}', must each be overridden at install
-time for the entire installation to be relocated.  The approach of
-makefile variable overrides for each directory variable is required by
-the GNU Coding Standards, and ideally causes no recompilation.
-However, some platforms have known limitations with the semantics of
-shared libraries that end up requiring recompilation when using this
-method, particularly noticeable in packages that use GNU Libtool.
+'${prefix}'.  Any directories that were specified during 'configure',
+but not in terms of '${prefix}', must each be overridden at install time
+for the entire installation to be relocated.  The approach of makefile
+variable overrides for each directory variable is required by the GNU
+Coding Standards, and ideally causes no recompilation.  However, some
+platforms have known limitations with the semantics of shared libraries
+that end up requiring recompilation when using this method, particularly
+noticeable in packages that use GNU Libtool.
 
-   The second method involves providing the `DESTDIR' variable.  For
-example, `make install DESTDIR=/alternate/directory' will prepend
-`/alternate/directory' before all installation names.  The approach of
-`DESTDIR' overrides is not required by the GNU Coding Standards, and
+   The second method involves providing the 'DESTDIR' variable.  For
+example, 'make install DESTDIR=/alternate/directory' will prepend
+'/alternate/directory' before all installation names.  The approach of
+'DESTDIR' overrides is not required by the GNU Coding Standards, and
 does not work on platforms that have drive letters.  On the other hand,
 it does better at avoiding recompilation issues, and works well even
-when some directory options were not specified in terms of `${prefix}'
-at `configure' time.
+when some directory options were not specified in terms of '${prefix}'
+at 'configure' time.
 
 Optional Features
 =================
 
    If the package supports it, you can cause programs to be installed
-with an extra prefix or suffix on their names by giving `configure' the
-option `--program-prefix=PREFIX' or `--program-suffix=SUFFIX'.
+with an extra prefix or suffix on their names by giving 'configure' the
+option '--program-prefix=PREFIX' or '--program-suffix=SUFFIX'.
 
-   Some packages pay attention to `--enable-FEATURE' options to
-`configure', where FEATURE indicates an optional part of the package.
-They may also pay attention to `--with-PACKAGE' options, where PACKAGE
-is something like `gnu-as' or `x' (for the X Window System).  The
-`README' should mention any `--enable-' and `--with-' options that the
+   Some packages pay attention to '--enable-FEATURE' options to
+'configure', where FEATURE indicates an optional part of the package.
+They may also pay attention to '--with-PACKAGE' options, where PACKAGE
+is something like 'gnu-as' or 'x' (for the X Window System).  The
+'README' should mention any '--enable-' and '--with-' options that the
 package recognizes.
 
-   For packages that use the X Window System, `configure' can usually
+   For packages that use the X Window System, 'configure' can usually
 find the X include and library files automatically, but if it doesn't,
-you can use the `configure' options `--x-includes=DIR' and
-`--x-libraries=DIR' to specify their locations.
+you can use the 'configure' options '--x-includes=DIR' and
+'--x-libraries=DIR' to specify their locations.
 
    Some packages offer the ability to configure how verbose the
-execution of `make' will be.  For these packages, running `./configure
+execution of 'make' will be.  For these packages, running './configure
 --enable-silent-rules' sets the default to minimal output, which can be
-overridden with `make V=1'; while running `./configure
+overridden with 'make V=1'; while running './configure
 --disable-silent-rules' sets the default to verbose, which can be
-overridden with `make V=0'.
+overridden with 'make V=0'.
 
 Particular systems
 ==================
 
-   On HP-UX, the default C compiler is not ANSI C compatible.  If GNU
-CC is not installed, it is recommended to use the following options in
+   On HP-UX, the default C compiler is not ANSI C compatible.  If GNU CC
+is not installed, it is recommended to use the following options in
 order to use an ANSI C compiler:
 
      ./configure CC="cc -Ae -D_XOPEN_SOURCE=500"
 
 and if that doesn't work, install pre-built binaries of GCC for HP-UX.
 
-   HP-UX `make' updates targets which have the same time stamps as
-their prerequisites, which makes it generally unusable when shipped
-generated files such as `configure' are involved.  Use GNU `make'
-instead.
+   HP-UX 'make' updates targets which have the same timestamps as their
+prerequisites, which makes it generally unusable when shipped generated
+files such as 'configure' are involved.  Use GNU 'make' instead.
 
    On OSF/1 a.k.a. Tru64, some versions of the default C compiler cannot
-parse its `<wchar.h>' header file.  The option `-nodtk' can be used as
-a workaround.  If GNU CC is not installed, it is therefore recommended
-to try
+parse its '<wchar.h>' header file.  The option '-nodtk' can be used as a
+workaround.  If GNU CC is not installed, it is therefore recommended to
+try
 
      ./configure CC="cc"
 
@@ -242,26 +240,26 @@ and if that doesn't work, try
 
      ./configure CC="cc -nodtk"
 
-   On Solaris, don't put `/usr/ucb' early in your `PATH'.  This
+   On Solaris, don't put '/usr/ucb' early in your 'PATH'.  This
 directory contains several dysfunctional programs; working variants of
-these programs are available in `/usr/bin'.  So, if you need `/usr/ucb'
-in your `PATH', put it _after_ `/usr/bin'.
+these programs are available in '/usr/bin'.  So, if you need '/usr/ucb'
+in your 'PATH', put it _after_ '/usr/bin'.
 
-   On Haiku, software installed for all users goes in `/boot/common',
-not `/usr/local'.  It is recommended to use the following options:
+   On Haiku, software installed for all users goes in '/boot/common',
+not '/usr/local'.  It is recommended to use the following options:
 
      ./configure --prefix=/boot/common
 
 Specifying the System Type
 ==========================
 
-   There may be some features `configure' cannot figure out
+   There may be some features 'configure' cannot figure out
 automatically, but needs to determine by the type of machine the package
 will run on.  Usually, assuming the package is built to be run on the
-_same_ architectures, `configure' can figure that out, but if it prints
+_same_ architectures, 'configure' can figure that out, but if it prints
 a message saying it cannot guess the machine type, give it the
-`--build=TYPE' option.  TYPE can either be a short name for the system
-type, such as `sun4', or a canonical name which has the form:
+'--build=TYPE' option.  TYPE can either be a short name for the system
+type, such as 'sun4', or a canonical name which has the form:
 
      CPU-COMPANY-SYSTEM
 
@@ -270,101 +268,101 @@ where SYSTEM can have one of these forms:
      OS
      KERNEL-OS
 
-   See the file `config.sub' for the possible values of each field.  If
-`config.sub' isn't included in this package, then this package doesn't
+   See the file 'config.sub' for the possible values of each field.  If
+'config.sub' isn't included in this package, then this package doesn't
 need to know the machine type.
 
    If you are _building_ compiler tools for cross-compiling, you should
-use the option `--target=TYPE' to select the type of system they will
+use the option '--target=TYPE' to select the type of system they will
 produce code for.
 
    If you want to _use_ a cross compiler, that generates code for a
 platform different from the build platform, you should specify the
 "host" platform (i.e., that on which the generated programs will
-eventually be run) with `--host=TYPE'.
+eventually be run) with '--host=TYPE'.
 
 Sharing Defaults
 ================
 
-   If you want to set default values for `configure' scripts to share,
-you can create a site shell script called `config.site' that gives
-default values for variables like `CC', `cache_file', and `prefix'.
-`configure' looks for `PREFIX/share/config.site' if it exists, then
-`PREFIX/etc/config.site' if it exists.  Or, you can set the
-`CONFIG_SITE' environment variable to the location of the site script.
-A warning: not all `configure' scripts look for a site script.
+   If you want to set default values for 'configure' scripts to share,
+you can create a site shell script called 'config.site' that gives
+default values for variables like 'CC', 'cache_file', and 'prefix'.
+'configure' looks for 'PREFIX/share/config.site' if it exists, then
+'PREFIX/etc/config.site' if it exists.  Or, you can set the
+'CONFIG_SITE' environment variable to the location of the site script.
+A warning: not all 'configure' scripts look for a site script.
 
 Defining Variables
 ==================
 
    Variables not defined in a site shell script can be set in the
-environment passed to `configure'.  However, some packages may run
+environment passed to 'configure'.  However, some packages may run
 configure again during the build, and the customized values of these
 variables may be lost.  In order to avoid this problem, you should set
-them in the `configure' command line, using `VAR=value'.  For example:
+them in the 'configure' command line, using 'VAR=value'.  For example:
 
      ./configure CC=/usr/local2/bin/gcc
 
-causes the specified `gcc' to be used as the C compiler (unless it is
+causes the specified 'gcc' to be used as the C compiler (unless it is
 overridden in the site shell script).
 
-Unfortunately, this technique does not work for `CONFIG_SHELL' due to
-an Autoconf limitation.  Until the limitation is lifted, you can use
-this workaround:
+Unfortunately, this technique does not work for 'CONFIG_SHELL' due to an
+Autoconf limitation.  Until the limitation is lifted, you can use this
+workaround:
 
      CONFIG_SHELL=/bin/bash ./configure CONFIG_SHELL=/bin/bash
 
-`configure' Invocation
+'configure' Invocation
 ======================
 
-   `configure' recognizes the following options to control how it
+   'configure' recognizes the following options to control how it
 operates.
 
-`--help'
-`-h'
-     Print a summary of all of the options to `configure', and exit.
+'--help'
+'-h'
+     Print a summary of all of the options to 'configure', and exit.
 
-`--help=short'
-`--help=recursive'
+'--help=short'
+'--help=recursive'
      Print a summary of the options unique to this package's
-     `configure', and exit.  The `short' variant lists options used
-     only in the top level, while the `recursive' variant lists options
-     also present in any nested packages.
+     'configure', and exit.  The 'short' variant lists options used only
+     in the top level, while the 'recursive' variant lists options also
+     present in any nested packages.
 
-`--version'
-`-V'
-     Print the version of Autoconf used to generate the `configure'
+'--version'
+'-V'
+     Print the version of Autoconf used to generate the 'configure'
      script, and exit.
 
-`--cache-file=FILE'
+'--cache-file=FILE'
      Enable the cache: use and save the results of the tests in FILE,
-     traditionally `config.cache'.  FILE defaults to `/dev/null' to
+     traditionally 'config.cache'.  FILE defaults to '/dev/null' to
      disable caching.
 
-`--config-cache'
-`-C'
-     Alias for `--cache-file=config.cache'.
+'--config-cache'
+'-C'
+     Alias for '--cache-file=config.cache'.
 
-`--quiet'
-`--silent'
-`-q'
+'--quiet'
+'--silent'
+'-q'
      Do not print messages saying which checks are being made.  To
-     suppress all normal output, redirect it to `/dev/null' (any error
+     suppress all normal output, redirect it to '/dev/null' (any error
      messages will still be shown).
 
-`--srcdir=DIR'
+'--srcdir=DIR'
      Look for the package's source code in directory DIR.  Usually
-     `configure' can determine that directory automatically.
+     'configure' can determine that directory automatically.
 
-`--prefix=DIR'
-     Use DIR as the installation prefix.  *note Installation Names::
-     for more details, including other options available for fine-tuning
-     the installation locations.
+'--prefix=DIR'
+     Use DIR as the installation prefix.  *note Installation Names:: for
+     more details, including other options available for fine-tuning the
+     installation locations.
 
-`--no-create'
-`-n'
+'--no-create'
+'-n'
      Run the configure checks, but stop before creating any output
      files.
 
-`configure' also accepts some other, not widely useful, options.  Run
-`configure --help' for more details.
+'configure' also accepts some other, not widely useful, options.  Run
+'configure --help' for more details.

--- a/README
+++ b/README
@@ -13,7 +13,8 @@ image registration on two images and outputs either the transformation parameter
 FOR THE IMPATIENT
 
 On a recent Ubuntu Linux, enter the following into a console window:
- sudo apt-get install build-essential libopencv-dev libboost-dev libboost-program-options-dev doxygen help2man
+ sudo apt-get install build-essential libopencv-dev libboost-dev libboost-program-options-dev doxygen help2man libtool
+ ./autogen.sh
  ./configure  CFLAGS="-Ofast" CXXFLAGS="-Ofast"
  make
  sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -42,14 +42,14 @@ else
 fi
 
 HAVE_OPENCV=false
-PKG_CHECK_MODULES(OPENCV, opencv4 >= 2.3.1, [HAVE_OPENCV=true], [true])
+PKG_CHECK_MODULES(OPENCV, opencv4 >= 4.5.4, [HAVE_OPENCV=true], [true])
 if test x$HAVE_OPENCV = xfalse; then
-  AC_MSG_WARN([*** opencv4 >= 2.3.1 not found - Cannot build the command line tool, which relies on OpenCV. Only the library will be built, because the lib has no dependency to OpenCV. http://opencvlibrary.sourceforge.net ***])
-  AC_DEFINE([HAVE_OPENCV],[0],[Define to 1 if you have OpenCV4 >= 2.3.1])
+  AC_MSG_WARN([*** opencv4 >= 4.5.4 not found - Cannot build the command line tool, which relies on OpenCV. Only the library will be built, because the lib has no dependency to OpenCV. http://opencvlibrary.sourceforge.net ***])
+  AC_DEFINE([HAVE_OPENCV],[0],[Define to 1 if you have OpenCV4 >= 4.5.4])
 else
   OPENCV_CFLAGS="$OPENCV_CFLAGS -DOPENCV_PREFIX=`pkg-config opencv --variable=prefix`"
   #OPENCV_INCLUDE=pkg-config opencv --variable=includedir_old
-  AC_DEFINE([HAVE_OPENCV],[1],[Define to 1 if you have OpenCV4 >= 2.3.1])
+  AC_DEFINE([HAVE_OPENCV],[1],[Define to 1 if you have OpenCV4 >= 4.5.4])
 fi
 AM_CONDITIONAL([HAVE_OPENCV], [test x$HAVE_OPENCV = xtrue])
 

--- a/configure.ac
+++ b/configure.ac
@@ -42,14 +42,14 @@ else
 fi
 
 HAVE_OPENCV=false
-PKG_CHECK_MODULES(OPENCV, opencv >= 2.3.1, [HAVE_OPENCV=true], [true])
+PKG_CHECK_MODULES(OPENCV, opencv4 >= 2.3.1, [HAVE_OPENCV=true], [true])
 if test x$HAVE_OPENCV = xfalse; then
-  AC_MSG_WARN([*** opencv >= 2.3.1 not found - Cannot build the command line tool, which relies on OpenCV. Only the library will be built, because the lib has no dependency to OpenCV. http://opencvlibrary.sourceforge.net ***])
-  AC_DEFINE([HAVE_OPENCV],[0],[Define to 1 if you have OpenCV >= 2.3.1])
+  AC_MSG_WARN([*** opencv4 >= 2.3.1 not found - Cannot build the command line tool, which relies on OpenCV. Only the library will be built, because the lib has no dependency to OpenCV. http://opencvlibrary.sourceforge.net ***])
+  AC_DEFINE([HAVE_OPENCV],[0],[Define to 1 if you have OpenCV4 >= 2.3.1])
 else
   OPENCV_CFLAGS="$OPENCV_CFLAGS -DOPENCV_PREFIX=`pkg-config opencv --variable=prefix`"
   #OPENCV_INCLUDE=pkg-config opencv --variable=includedir_old
-  AC_DEFINE([HAVE_OPENCV],[1],[Define to 1 if you have OpenCV >= 2.3.1])
+  AC_DEFINE([HAVE_OPENCV],[1],[Define to 1 if you have OpenCV4 >= 2.3.1])
 fi
 AM_CONDITIONAL([HAVE_OPENCV], [test x$HAVE_OPENCV = xtrue])
 

--- a/exe/CRegistrationController.cpp
+++ b/exe/CRegistrationController.cpp
@@ -100,8 +100,8 @@ void CRegistrationController::RegisterImage()
 	imgTmp = imread(m_sTFilename.c_str(), cv::IMREAD_GRAYSCALE);
 	if(!CheckImage(imgTmp, m_sTFilename))
 		exit(0);
-	uint32_t iyDim = imgTmp.cols;
-	uint32_t ixDim = imgTmp.rows;
+	uint32_t iyDim = imgTmp.rows;
+	uint32_t ixDim = imgTmp.cols;
 	t_pixel* pixelBytesTmp = (t_pixel *)imgTmp.data;
 
 	// load reference image

--- a/exe/CRegistrationController.cpp
+++ b/exe/CRegistrationController.cpp
@@ -96,26 +96,26 @@ void CRegistrationController::RegisterImage()
 {
 	// load template image
 	// ToDo: This class is too big. Refactor out an image class containing all image handling (maybe outlayering OpenCV) (and possibly also the cmdline param stuff at the bottom of this file).
-	IplImage* imgTmp = 0; 
-	imgTmp=cvLoadImage(m_sTFilename.c_str(), CV_LOAD_IMAGE_GRAYSCALE);
+	cv::Mat imgTmp;
+	imgTmp = imread(m_sTFilename.c_str(), cv::IMREAD_GRAYSCALE);
 	if(!CheckImage(imgTmp, m_sTFilename))
 		exit(0);
-	uint32_t iyDim = imgTmp->height;
-	uint32_t ixDim = imgTmp->width;
-	t_pixel* pixelBytesTmp = (t_pixel *)imgTmp->imageData;
+	uint32_t iyDim = imgTmp.cols;
+	uint32_t ixDim = imgTmp.rows;
+	t_pixel* pixelBytesTmp = (t_pixel *)imgTmp.data;
 
 	// load reference image
-	IplImage* imgRef = 0; 
-	imgRef=cvLoadImage(m_sRFilename.c_str(), CV_LOAD_IMAGE_GRAYSCALE);
+	cv::Mat imgRef; 
+	imgRef=imread(m_sRFilename.c_str(), cv::IMREAD_GRAYSCALE);
 	if(!CheckImage(imgRef, m_sRFilename, ixDim, iyDim))
 		exit(0);
-	t_pixel* pixelBytesRef = (t_pixel *)imgRef->imageData;
+	t_pixel* pixelBytesRef = (t_pixel *)imgRef.data;
 
 	// invert images if requested so by the user
 	if(true == m_bInvert)
 	{
-	    cvXorS(imgTmp, cvScalar(255), imgTmp);
-	    cvXorS(imgRef, cvScalar(255), imgRef);
+	    cv::bitwise_xor(imgTmp, cv::Scalar(255), imgTmp);
+	    cv::bitwise_xor(imgRef, cv::Scalar(255), imgRef);
 	}
 
 //todo: the lib can do this, we can remove it here (verify !)
@@ -196,7 +196,7 @@ void CRegistrationController::RegisterImage()
 	string sResult = (boost::format("Iterations = %1%, SSD = %2%, w = [%3% deg, %4% px, %5% px]") % iNumIter % SSD % rotation % xShift % yShift).str();
 	printf("%s\n", sResult.c_str());
 
-    IplImage* imgTmpTrns=NULL;
+    cv::Mat imgTmpTrns;
     bool bNeedTransImage = (!m_bNoGui) || (0<m_sSaveTransImage.size());
     Limereg_Image tmpTrnsPixels;
     if(bNeedTransImage)
@@ -204,12 +204,12 @@ void CRegistrationController::RegisterImage()
         // invert images backwards to the originally loaded ones, if it had been reverted before
         if(true == m_bInvert)
         {
-            cvXorS(imgTmp, cvScalar(255), imgTmp);
-            cvXorS(imgRef, cvScalar(255), imgRef);
+            cv::bitwise_xor(imgTmp, cv::Scalar(255), imgTmp);
+            cv::bitwise_xor(imgRef, cv::Scalar(255), imgRef);
         }
 
         // calculate transformed template image
-        imgTmpTrns=cvCloneImage(imgTmp);
+        imgTmpTrns=imgTmp.clone();
 
         tmpTrnsPixels.pixelBuffer = (t_pixel *)imgTmpTrns->imageData;
         tmpTrnsPixels.imageWidth = (uint32_t)ixDim;
@@ -298,7 +298,7 @@ void CRegistrationController::RegisterImage()
 /**
 * Check wether image file is valid. (Will also check image size)
 */
-bool CRegistrationController::CheckImage(IplImage* Image, const string& sFilename, uint32_t XDim, uint32_t YDim)
+bool CRegistrationController::CheckImage(cv::Mat Image, const string& sFilename, uint32_t XDim, uint32_t YDim)
 {
 	//Show all errors at once to the user (e.g. wrong color, height and width)
 	bool bRetVal = CheckImage(Image, sFilename);
@@ -321,7 +321,7 @@ bool CRegistrationController::CheckImage(IplImage* Image, const string& sFilenam
 /**
 * Check wether image file is valid. (Will not check image size)
 */
-bool CRegistrationController::CheckImage(IplImage* Image, const string& sFilename)
+bool CRegistrationController::CheckImage(cv::Mat Image, const string& sFilename)
 {
 	if(NULL == Image)
 	{

--- a/exe/CRegistrationController.cpp
+++ b/exe/CRegistrationController.cpp
@@ -211,7 +211,7 @@ void CRegistrationController::RegisterImage()
         // calculate transformed template image
         imgTmpTrns=imgTmp.clone();
 
-        tmpTrnsPixels.pixelBuffer = (t_pixel *)imgTmpTrns->imageData;
+        tmpTrnsPixels.pixelBuffer = (t_pixel *)imgTmpTrns.data;
         tmpTrnsPixels.imageWidth = (uint32_t)ixDim;
         tmpTrnsPixels.imageHeight = (uint32_t)iyDim;
         refPixels.pixelType = Limereg_Image::Limereg_Grayscale_8;
@@ -227,7 +227,7 @@ void CRegistrationController::RegisterImage()
         if(0<m_sSaveTransImage.size())
         {
             printf("Saving result to file '%s'.\n", m_sSaveTransImage.c_str());
-            int iRetval = cvSaveImage(m_sSaveTransImage.c_str(), imgTmpTrns);
+            int iRetval = imwrite(m_sSaveTransImage.c_str(), imgTmpTrns);
             /*if(0!=iRetval)
             {
                 printf("ERROR, CANNOT SAVE IMAGE, CHECK FILENAME.\n");
@@ -238,12 +238,12 @@ void CRegistrationController::RegisterImage()
 	if(!m_bNoGui)
 	{
 		// calculate difference image between ORIGINAL template image and reference image
-		IplImage* imgDiffOrig=NULL;
-		imgDiffOrig=cvCloneImage(imgTmp);
+		cv::Mat imgDiffOrig;
+		imgDiffOrig=imgTmp.clone();
 
 
 		Limereg_Image imgDiffOrigPixels;
-		imgDiffOrigPixels.pixelBuffer = (t_pixel *)imgDiffOrig->imageData;
+		imgDiffOrigPixels.pixelBuffer = (t_pixel *)imgDiffOrig.data;
 		imgDiffOrigPixels.imageWidth = (uint32_t)ixDim;
 		imgDiffOrigPixels.imageHeight = (uint32_t)iyDim;
 		refPixels.pixelType = Limereg_Image::Limereg_Grayscale_8;
@@ -253,11 +253,11 @@ void CRegistrationController::RegisterImage()
 		Limereg_CalculateDiffImage(&refPixels, &tmpPixels, &imgDiffOrigPixels);
 
 		// calculate difference image between TRANSFORMED template image and reference image
-		IplImage* imgDiffFinal=NULL;
-		imgDiffFinal=cvCloneImage(imgTmp);
+		cv::Mat imgDiffFinal;
+		imgDiffFinal=imgTmp.clone();
 
 		Limereg_Image imgDiffFinalPixels;
-		imgDiffFinalPixels.pixelBuffer = (t_pixel *)imgDiffFinal->imageData;
+		imgDiffFinalPixels.pixelBuffer = (t_pixel *)imgDiffFinal.data;
 		imgDiffFinalPixels.imageWidth = (uint32_t)ixDim;
 		imgDiffFinalPixels.imageHeight = (uint32_t)iyDim;
 		refPixels.pixelType = Limereg_Image::Limereg_Grayscale_8;
@@ -277,22 +277,22 @@ void CRegistrationController::RegisterImage()
 		ShowImage(imgDiffFinal, "Difference AFTER", 1, 1, ixDisplayImgSize, iyDisplayImgSize);
 
 		// Give windows some time to paint the content
-		cvWaitKey(1);
+		cv::waitKey(1);
 
 		// wait for a key
-		cvWaitKey(0);
+		cv::waitKey(0);
 
 		// release the images
-		cvReleaseImage(&imgDiffFinal);
-		cvReleaseImage(&imgDiffOrig);
+		imgDiffFinal.release();
+		imgDiffOrig.release();
 	}
 
 	if(bNeedTransImage)
 	{
-		cvReleaseImage(&imgTmpTrns);
+		imgTmpTrns.release();
 	}
-	cvReleaseImage(&imgRef);
-	cvReleaseImage(&imgTmp);
+	imgRef.release();
+	imgTmp.release();
 }
 
 /**
@@ -302,16 +302,16 @@ bool CRegistrationController::CheckImage(cv::Mat Image, const string& sFilename,
 {
 	//Show all errors at once to the user (e.g. wrong color, height and width)
 	bool bRetVal = CheckImage(Image, sFilename);
-	if(NULL == Image)
+	if(NULL == Image.data)
 	{
 		//Function call above allready reported an error
 		return false;
 	}
 
 	//Check for equal size
-	if(Image->width != XDim || Image->height != YDim)
+	if(Image.cols != XDim || Image.rows != YDim)
 	{
-		printf("%s width must be %i and is %i, the height must be %i and is %i.\n", gcsCannotLoadImage.c_str(), XDim ,Image->width, YDim ,Image->height);
+		printf("%s width must be %i and is %i, the height must be %i and is %i.\n", gcsCannotLoadImage.c_str(), XDim ,Image.cols, YDim ,Image.rows);
 		bRetVal=false;
 	}
 
@@ -323,7 +323,7 @@ bool CRegistrationController::CheckImage(cv::Mat Image, const string& sFilename,
 */
 bool CRegistrationController::CheckImage(cv::Mat Image, const string& sFilename)
 {
-	if(NULL == Image)
+	if(NULL == Image.data)
 	{
 		printf("%s '%s'", gcsCannotLoadImage.c_str(), sFilename.c_str());
 		return false;
@@ -333,15 +333,15 @@ bool CRegistrationController::CheckImage(cv::Mat Image, const string& sFilename)
 	bool bRetVal=true;
 
 	const int iAllowedChannelCount=1;
-	if(Image->nChannels != iAllowedChannelCount)
+	if(Image.channels() != iAllowedChannelCount)
 	{
-		printf("%s Color channel count must be %i but is %i.\n", gcsCannotLoadImage.c_str(), iAllowedChannelCount, Image->nChannels);
+		printf("%s Color channel count must be %i but is %i.\n", gcsCannotLoadImage.c_str(), iAllowedChannelCount, Image.channels());
 		bRetVal=false;
 	}
 
-	if(Image->height<=0)
+	if(Image.rows<=0)
 	{
-		printf("%s Image dimensions must be bigger than 0 (but are %i).\n", gcsCannotLoadImage.c_str(), Image->height);
+		printf("%s Image dimensions must be bigger than 0 (but are %i).\n", gcsCannotLoadImage.c_str(), Image.rows);
 		bRetVal=false;
 	}
 
@@ -352,11 +352,11 @@ bool CRegistrationController::CheckImage(cv::Mat Image, const string& sFilename)
 * Display image data of 'image' in window named 'WindowName' at the zero based image position xPos, yPos.
 * The position is calculated based on the image dimensions WndSize (e.g. 1,2 an image in the second row and third column)
 */
-void CRegistrationController::ShowImage(IplImage* Image, const string& WindowName, uint32_t xPos, uint32_t yPos, uint32_t WndSizeX, uint32_t WndSizeY)
+void CRegistrationController::ShowImage(cv::Mat Image, const string& WindowName, uint32_t xPos, uint32_t yPos, uint32_t WndSizeX, uint32_t WndSizeY)
 {
-	cvNamedWindow(WindowName.c_str(), 0); 
-	MoveWindow(WindowName, xPos, yPos, WndSizeX, WndSizeY);
-	cvShowImage(WindowName.c_str(), Image );
+	cv::namedWindow(WindowName.c_str(), 0); 
+	cv::moveWindow(WindowName, xPos, yPos); //, WndSizeX, WndSizeY);
+	cv::imshow(WindowName.c_str(), Image );
 }
 
 /**
@@ -370,8 +370,8 @@ void CRegistrationController::MoveWindow(const string& WindowName,  uint32_t xPo
 
 	uint32_t xPosPixel = xPos*(iXSpacer+WndSizeX);
 	uint32_t yPosPixel = yPos*(iYSpacer+WndSizeY);
-	cvMoveWindow(WindowName.c_str(), xPosPixel, yPosPixel);
-	cvResizeWindow(WindowName.c_str(), WndSizeX, WndSizeY);
+	cv::moveWindow(WindowName.c_str(), xPosPixel, yPosPixel);
+	cv::resizeWindow(WindowName.c_str(), WndSizeX, WndSizeY);
 }
 
 /**

--- a/exe/CRegistrationController.h
+++ b/exe/CRegistrationController.h
@@ -58,9 +58,9 @@ public:
 
 private:
 	bool ParseParameters(int argc, char ** argv);
-	bool CheckImage(IplImage* Image, const string& Filename, uint32_t XDim, uint32_t YDim);
-	bool CheckImage(IplImage* Image, const string& Filename);
-	void ShowImage(IplImage* Image, const string& WindowName, uint32_t xPos, uint32_t yPos, uint32_t WndSizeX, uint32_t WndSizeY);
+	bool CheckImage(cv::Mat Image, const string& Filename, uint32_t XDim, uint32_t YDim);
+	bool CheckImage(cv::Mat Image, const string& Filename);
+	void ShowImage(cv::Mat Image, const string& WindowName, uint32_t xPos, uint32_t yPos, uint32_t WndSizeX, uint32_t WndSizeY);
 	void MoveWindow(const string& WindowName,  uint32_t xPos, uint32_t yPos, uint32_t WndSizeX, uint32_t WndSizeY);
 
 	//cmdline params

--- a/exe/stdafx.h
+++ b/exe/stdafx.h
@@ -95,7 +95,7 @@ using std::ostream;
 //BOOST library (This application makes little usage of boost. If you don't want to use it should be a matter of one hour to get rid of it.)
 #include <boost/format.hpp>
 #include <boost/foreach.hpp>
-#include <boost/progress.hpp>
+#include <boost/timer/progress_display.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
 //Common includes of our own files (static helper classes)
@@ -103,8 +103,8 @@ using std::ostream;
 
 //OpenCV (image processing library, only used for loading and displaying/storing the images. If you don't like it it should be just a matter of one hour to get rid of it - if you have
 //an image in- and output alternative readyly available)
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/opencv.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 //Commonly used application headers
 #include "limereg_common.h"


### PR DESCRIPTION
The command line tool uses the C version of OpenCV which I understand has been deprecated for some time, so I updated all the references to work in the C++ version of OpenCV4.

I wasn't sure how to fix the package check.  I set the check to look for 4.5.4 which is what I have installed and have tested, but it appears to pass no matter what version is specified, as long as it's opencv4.

This is my first ever contribution to anything open source, so be gentle!